### PR TITLE
(KeyValue).String() empty field to null

### DIFF
--- a/steamvdf/key_value.go
+++ b/steamvdf/key_value.go
@@ -72,6 +72,14 @@ func (kv KeyValue) String() string {
 		return kv.Value
 	}
 
+	if len(kv.Children) == 0 {
+		b, err := json.Marshal(map[string]interface{}{kv.Key: nil})
+		if err != nil || string(b) == "{}" {
+			return ""
+		}
+		return string(b)
+	}
+
 	b, err := json.Marshal(toMap(kv))
 	if err != nil || string(b) == "{}" {
 		return ""
@@ -103,10 +111,12 @@ func toMap(kv KeyValue) map[string]interface{} {
 
 	for _, child := range kv.Children {
 
-		if child.Value == "" {
-			m[child.Key] = toMap(child)
-		} else {
+		if child.Value != "" {
 			m[child.Key] = child.Value
+		} else if len(child.Children) == 0 {
+			m[child.Key] = nil
+		} else {
+			m[child.Key] = toMap(child)
 		}
 	}
 

--- a/steamvdf/vdf_test.go
+++ b/steamvdf/vdf_test.go
@@ -1,6 +1,7 @@
 package steamvdf
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -44,12 +45,30 @@ func TestReadBinary(t *testing.T) {
 		}
 
 		switch file {
+		case "testdata/app_600760.vdf":
+
+			fmt.Println("Testing " + file)
+
+			str := kv.String()
+
+			assert.Assert(t, strings.Contains(str, "\"gamedir\":null"), "kv.String()", "empty value is not null")
+
+			var vdf struct {
+				Extended struct {
+					Gamedir string `json:"gamedir"`
+				} `json:"extended"`
+			}
+
+			err := json.Unmarshal([]byte(str), &vdf)
+
+			assert.Assert(t, err == nil, "json.Unmarshal()", "expected to unmarshal empty string value", "error", err)
+
 		case "testdata/app_212200.vdf":
 
 			fmt.Println("Testing " + file)
 
 			assert.Assert(t, strings.Contains(kv.String(), `\\\"`))
-			
+
 		case "testdata/app_10.vdf":
 
 			fmt.Println("Testing " + file)


### PR DESCRIPTION
## Issue
Current implementation improperly converts the fields with empty string values in `(KeyValue).String()` method.

## Example

`testdata/app_600760.vdf` file:
```
"gamedir"		"" // usually string value
```

After `String()` method:

* Expected
```json
{
    "gamedir":null
}
```

* Got
```json
{
    "gamedir":{}
}
```

## Explanation
Current implementation will set the empty map `{}` when `KeyValue.Value == ""` because it calls the `toMap()` function. This leads to issues when expecting a field of type `string`, because an empty object `{}` cannot be unmarshaled into type `string`.

Code at issue:
```go
m := map[string]interface{}{}

for _, child := range kv.Children {

	if child.Value == "" {
		m[child.Key] = toMap(child) // will result in {}
	} else {
		m[child.Key] = child.Value
	}
}
```

Unmarshal issue:
```go
var vdf struct {
	Extended struct {
		Gamedir string `json:"gamedir"`
	} `json:"extended"`
}

err := json.Unmarshal([]byte(kv.String()), &vdf) // fails because "gamedir":{} in resulting string
```

## Proposed change
The proposed change solves the issue by checking if there are no `KeyValue.Children`. In that case, it will set `nil` (`null`) to the field which will properly unmarshal whichever the expected type is.

```diff
// toMap() func
+ if child.Value != "" {
+ 	m[child.Key] = child.Value
+ } else if len(child.Children) == 0 {
+ 	m[child.Key] = nil
+ } else {
+ 	m[child.Key] = toMap(child)
+ }
```

```diff
// (KeyValue).String() method
+ if len(kv.Children) == 0 {
+ 	b, err := json.Marshal(map[string]interface{}{kv.Key: nil})
+ 	if err != nil || string(b) == "{}" {
+ 		return ""
+ 	}
+ 	return string(b)
+ }
```

## Testing vdf conversion
Added the test case for `testdata/app_600760.vdf` file, which has an empty child field.

```diff
+ case "testdata/app_600760.vdf":
+
+ 	fmt.Println("Testing " + file)
+
+ 	str := kv.String()
+
+ 	assert.Assert(t, strings.Contains(str, "\"gamedir\":null"), "kv.String()", "empty value is not null")
+
+ 	var vdf struct {
+ 		Extended struct {
+ 			Gamedir string `json:"gamedir"`
+ 		} `json:"extended"`
+ 	}
+
+ 	err := json.Unmarshal([]byte(str), &vdf)
+
+ 	assert.Assert(t, err == nil, "json.Unmarshal()", "expected to unmarshal empty string value", "error", err)
```